### PR TITLE
Fix bug in wannier90 hr reader

### DIFF
--- a/python/triqs_tprf/wannier90.py
+++ b/python/triqs_tprf/wannier90.py
@@ -74,7 +74,7 @@ def parse_hopping_from_wannier90_hr_dat(filename):
 
     deg = np.array([])
     for line in lines[:nlines]:
-        deg = np.concatenate((deg, np.loadtxt(StringIO(line), dtype=np.int)))
+        deg = np.concatenate((deg, np.loadtxt(StringIO(line), dtype=np.int, ndmin=1)))
     
     assert( deg.shape == (nrpts,) )
 


### PR DESCRIPTION
Dear all,

this pull-request fixes a bug when reading R-points from wannier90 case_hr.dat files.
It makes sure that if there is only one R-point in the last line that this is still returned as
as a 1D array by ```numpy.loadtxt```, by setting ```ndmin``` explicitly to 1.

This is a tiny 1-line bugfix, thus should be directly merge-able.
Please also consider backporting it to 2.2.x. and 2.1.x.

Best, Manuel