### PR TITLE
pytriqs.utility.mpi import in lattice module

### DIFF
--- a/python/triqs_tprf/lattice_desc.py
+++ b/python/triqs_tprf/lattice_desc.py
@@ -6,7 +6,7 @@ from cpp2py.wrap_generator import *
 module = module_(full_name = "lattice", doc = r"Lattice functionality", app_name = "triqs_tprf")
 
 # Imports
-module.add_imports(*['pytriqs.gf', 'pytriqs.lattice'])
+module.add_imports(*['pytriqs.gf', 'pytriqs.lattice', 'pytriqs.utility.mpi'])
 
 # Add here all includes
 module.add_include("triqs_tprf/lattice.hpp")

--- a/python/triqs_tprf/lattice_desc.py
+++ b/python/triqs_tprf/lattice_desc.py
@@ -259,7 +259,7 @@ module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::lindhard_chi00_wk (triqs_
       poles are non-degenerate. The degenerate case produces an additional frequency independent
       contribution (the last term on the last row).""")
 
-module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::solve_rpa_PH (triqs_tprf::chi_wk_vt chi0, array_view<std::complex<double>,4> U)", doc = r"""Random Phase Approximation (RPA) in the particle-hole channel
+module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::solve_rpa_PH (triqs_tprf::chi_wk_vt chi0, array_view<std::complex<double>, 4> U)", doc = r"""Random Phase Approximation (RPA) in the particle-hole channel
 
      Computes the equation
 
@@ -496,11 +496,11 @@ out
 
 module.add_function ("triqs_tprf::gk_iw_t triqs_tprf::eliashberg_g_delta_g_product (triqs_tprf::gk_iw_vt g_wk, triqs_tprf::gk_iw_vt delta_wk)", doc = r"""""")
 
-module.add_function ("std::tuple<chi_wk_vt,chi_k_vt> triqs_tprf::split_into_dynamic_wk_and_constant_k (triqs_tprf::chi_wk_vt Gamma_pp)", doc = r"""""")
+module.add_function ("std::tuple<chi_wk_vt, chi_k_vt> triqs_tprf::split_into_dynamic_wk_and_constant_k (triqs_tprf::chi_wk_vt Gamma_pp)", doc = r"""""")
 
-module.add_function ("std::tuple<chi_tr_vt,chi_r_vt> triqs_tprf::dynamic_and_constant_to_tr (triqs_tprf::chi_wk_vt Gamma_pp_dyn_wk, triqs_tprf::chi_k_vt Gamma_pp_const_k)", doc = r"""""")
+module.add_function ("std::tuple<chi_tr_vt, chi_r_vt> triqs_tprf::dynamic_and_constant_to_tr (triqs_tprf::chi_wk_vt Gamma_pp_dyn_wk, triqs_tprf::chi_k_vt Gamma_pp_const_k)", doc = r"""""")
 
-module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::gamma_PP_singlet (triqs_tprf::chi_wk_vt chi_c, triqs_tprf::chi_wk_vt chi_s, array_view<std::complex<double>,4> U_c, array_view<std::complex<double>,4> U_s)", doc = r"""Gamma particle-particle singlet
+module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::gamma_PP_singlet (triqs_tprf::chi_wk_vt chi_c, triqs_tprf::chi_wk_vt chi_s, array_view<std::complex<double>, 4> U_c, array_view<std::complex<double>, 4> U_s)", doc = r"""Gamma particle-particle singlet
 
      Computes the particle-particle vertex for singlet pairing in the RPA limit
 
@@ -532,7 +532,7 @@ Returns
 out
      :math:`\Gamma^{(\mathrm{singlet})}_{a\bar{b}c\bar{d}}(\mathbf{k}, i\omega_n)`""")
 
-module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::gamma_PP_triplet (triqs_tprf::chi_wk_vt chi_c, triqs_tprf::chi_wk_vt chi_s, array_view<std::complex<double>,4> U_c, array_view<std::complex<double>,4> U_s)", doc = r"""Gamma particle-particle triplet
+module.add_function ("triqs_tprf::chi_wk_t triqs_tprf::gamma_PP_triplet (triqs_tprf::chi_wk_vt chi_c, triqs_tprf::chi_wk_vt chi_s, array_view<std::complex<double>, 4> U_c, array_view<std::complex<double>, 4> U_s)", doc = r"""Gamma particle-particle triplet
 
      Computes the particle-particle vertex for triplet pairing in the RPA limit
 
@@ -564,7 +564,7 @@ Returns
 out
      :math:`\Gamma^{(\mathrm{triplet})}_{a\bar{b}c\bar{d}}(\mathbf{k}, i\omega_n)`""")
 
-module.add_function ("array<std::complex<double>,6> triqs_tprf::cluster_mesh_fourier_interpolation (array<double,2> k_vecs, triqs_tprf::chi_wr_cvt chi)", doc = r"""""")
+module.add_function ("array<std::complex<double>, 6> triqs_tprf::cluster_mesh_fourier_interpolation (array<double, 2> k_vecs, triqs_tprf::chi_wr_cvt chi)", doc = r"""""")
 
 module.add_function ("triqs_tprf::chi_tr_t triqs_tprf::chi0_tr_from_grt_PH (triqs_tprf::g_tr_cvt g_tr)", doc = r"""Generalized susceptibility imaginary time bubble in the particle-hole channel :math:`\chi^{(0)}_{\bar{a}b\bar{c}d}(\tau, \mathbf{r})`
 
@@ -924,13 +924,13 @@ Returns
 out
      Generalized lattice susceptibility :math:`\chi_{\bar{a}b\bar{c}d}(\omega, \mathbf{k})`.""")
 
-module.add_function ("gf<cartesian_product<triqs::lattice::brillouin_zone,triqs::gfs::imfreq>,tensor_valued<4>> triqs_tprf::chiq_sum_nu_from_g_wk_and_gamma_PH (triqs_tprf::gk_iw_t g_wk, triqs_tprf::g2_iw_vt gamma_ph_wnn, int tail_corr_nwf = -1)", doc = r"""""")
+module.add_function ("gf<cartesian_product<triqs::lattice::brillouin_zone, triqs::gfs::imfreq>, tensor_valued<4> > triqs_tprf::chiq_sum_nu_from_g_wk_and_gamma_PH (triqs_tprf::gk_iw_t g_wk, triqs_tprf::g2_iw_vt gamma_ph_wnn, int tail_corr_nwf = -1)", doc = r"""""")
 
-module.add_function ("gf<cartesian_product<triqs::lattice::brillouin_zone,triqs::gfs::imfreq>,tensor_valued<4>> triqs_tprf::chiq_sum_nu_from_e_k_sigma_w_and_gamma_PH (double mu, triqs_tprf::ek_vt e_k, triqs_tprf::g_iw_vt sigma_w, triqs_tprf::g2_iw_vt gamma_ph_wnn, int tail_corr_nwf = -1)", doc = r"""""")
+module.add_function ("gf<cartesian_product<triqs::lattice::brillouin_zone, triqs::gfs::imfreq>, tensor_valued<4> > triqs_tprf::chiq_sum_nu_from_e_k_sigma_w_and_gamma_PH (double mu, triqs_tprf::ek_vt e_k, triqs_tprf::g_iw_vt sigma_w, triqs_tprf::g2_iw_vt gamma_ph_wnn, int tail_corr_nwf = -1)", doc = r"""""")
 
-module.add_function ("gf<cartesian_product<triqs::lattice::brillouin_zone,triqs::gfs::imfreq>,tensor_valued<4>> triqs_tprf::chiq_sum_nu (triqs_tprf::chiq_t chiq)", doc = r"""""")
+module.add_function ("gf<cartesian_product<triqs::lattice::brillouin_zone, triqs::gfs::imfreq>, tensor_valued<4> > triqs_tprf::chiq_sum_nu (triqs_tprf::chiq_t chiq)", doc = r"""""")
 
-module.add_function ("gf<triqs::gfs::imfreq,tensor_valued<4>> triqs_tprf::chiq_sum_nu_q (triqs_tprf::chiq_t chiq)", doc = r"""""")
+module.add_function ("gf<triqs::gfs::imfreq, tensor_valued<4> > triqs_tprf::chiq_sum_nu_q (triqs_tprf::chiq_t chiq)", doc = r"""""")
 
 
 


### PR DESCRIPTION
Make sure that pytriqs.utility.mpi is imported in initialization of lattice python module to guarantee
that mpi is properly initialized.